### PR TITLE
Fix: null check on node in compositor3.js

### DIFF
--- a/web/compositor3.js
+++ b/web/compositor3.js
@@ -186,7 +186,7 @@ app.registerExtension({
             const e = event.detail.output;
             const nodeId = event.detail.node;
             const node = Editor.hook(nodeId);
-            if (node.type != "Compositor3") {
+            if (!node || node.type != "Compositor3") {
                 // console.log(node.type);
                 return;
             }


### PR DESCRIPTION
This node pack is available on https://cloud.comfy.org/ where we collect error reporting. A missing null check here causes a large number of errors (553 in 2 days). Thank you for providing these great nodes to community, I hope this PR can help improve them.