### PR TITLE
fix(Compositor4): load composite via [output] annotation instead of ../ traversal

### DIFF
--- a/Compositor4.py
+++ b/Compositor4.py
@@ -237,8 +237,12 @@ class Compositor4(io.ComfyNode):
             blocker_result = tuple([ExecutionBlocker(None)] * 3)  # V4: 3 outputs now
             return io.NodeOutput(*blocker_result, ui=ui)
         
-        # Construct path based on saveFolder
-        folder_path = f"../{saveFolder}/compositor/{imageName}"
+        # Construct path based on saveFolder.
+        # Use ComfyUI's annotation syntax ("name [output]") instead of a "../output/"
+        # relative traversal: recent ComfyUI hardened folder_paths with an
+        # is_within_directory() guard that rejects paths escaping the input dir,
+        # which broke the old "../{saveFolder}/..." form (always "Image not found").
+        folder_path = f"compositor/{imageName} [{saveFolder}]"
         imageExists = folder_paths.exists_annotated_filepath(folder_path)
         if not imageExists:
             # Return ExecutionBlocker for all outputs if blocked


### PR DESCRIPTION
## Problem

On recent ComfyUI, Compositor V4 always fails to load its saved composite and logs
`Image not found: ../output/compositor/<file>`, even though the file exists in
`output/compositor/`. See #121 for the full trace.

The load path is built as a relative traversal:

```python
folder_path = f"../{saveFolder}/compositor/{imageName}"
```

With no `[output]` annotation, `folder_paths` resolves this against the **input**
directory (`input/../output/compositor/<file>`). Recent ComfyUI added an
`is_within_directory()` traversal guard to `exists_annotated_filepath()` /
`get_annotated_filepath()`, which rejects any path escaping the base dir. So the
check returns `False` (and `get_annotated_filepath` would `raise ValueError`),
and the node blocks every run.

## Fix

Use ComfyUI's annotation syntax. `saveFolder ∈ {temp, input, output}` maps 1:1 to
the `[temp]` / `[input]` / `[output]` tag — and to the exact base dir the save
side (`CompositorConfig4.saveImageToCompositorFolder`) already writes to:

```diff
-        # Construct path based on saveFolder
-        folder_path = f"../{saveFolder}/compositor/{imageName}"
+        folder_path = f"compositor/{imageName} [{saveFolder}]"
```

## Why it's correct

- `annotated_filepath("compositor/<file> [output]")` strips the tag and sets
  `base_dir = get_output_directory()`, giving `output/compositor/<file>` — inside
  the base dir, so the traversal guard passes.
- Realigns load with save: `saveImageToCompositorFolder` already uses
  `get_output_directory()` / `get_input_directory()` / `get_temp_directory()` +
  `compositor/`. This makes the load resolve to the same location for all three
  `saveFolder` values.
- **Backward compatible** — the `[output]`-style annotation has been supported by
  `folder_paths.annotated_filepath` for a long time, so this works on both
  hardened and older ComfyUI builds.

## Testing

- Repro before fix: `saveFolder=output`, composite present on disk →
  `Image not found: ../output/compositor/<file>`, node blocks.
- After fix (ComfyUI restarted): the node loads the composite and outputs the
  image; no error in logs; node imports cleanly.
- Spot-checked that `saveFolder=input` and `saveFolder=temp` map to the matching
  base dirs used by the save side.

## Scope

`Compositor3.py` (V3) is **not** affected — it passes `imageName` directly to
`exists_annotated_filepath` with no `../` prefix — so it's left untouched.

Fixes #121